### PR TITLE
Updated sample to work with ADAL 6.0.0

### DIFF
--- a/QuickStart.xcodeproj/project.pbxproj
+++ b/QuickStart.xcodeproj/project.pbxproj
@@ -19,9 +19,9 @@
 /* Begin PBXFileReference section */
 		4B5985AC4EC72AE16C81F234 /* Pods-QuickStart.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStart.debug.xcconfig"; path = "Pods/Target Support Files/Pods-QuickStart/Pods-QuickStart.debug.xcconfig"; sourceTree = "<group>"; };
 		83ED874D158D34B63DEB6793 /* Pods-QuickStart.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStart.release.xcconfig"; path = "Pods/Target Support Files/Pods-QuickStart/Pods-QuickStart.release.xcconfig"; sourceTree = "<group>"; };
-		C7CBF881BF504F0A15F7FD5C /* Pods-QuickStart.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStart.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MSALiOS/Pods-QuickStart.debug.xcconfig"; sourceTree = "<group>"; };
+		C7CBF881BF504F0A15F7FD5C /* Pods-QuickStart.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStart.debug.xcconfig"; path = "Pods/Target Support Files/Pods-QuickStart/Pods-QuickStart.debug.xcconfig"; sourceTree = "<group>"; };
 		CA7653BB6CB4821B302534A3 /* Pods_QuickStart.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_QuickStart.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		DF06CB9178C218430A5EDADB /* Pods-QuickStart.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStart.release.xcconfig"; path = "Pods/Target Support Files/Pods-MSALiOS/Pods-QuickStart.release.xcconfig"; sourceTree = "<group>"; };
+		DF06CB9178C218430A5EDADB /* Pods-QuickStart.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStart.release.xcconfig"; path = "Pods/Target Support Files/Pods-QuickStart/Pods-QuickStart.release.xcconfig"; sourceTree = "<group>"; };
 		FB1A4AF3214992180062E42D /* ADAL.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ADAL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FBA79E9D1E9A038700179A54 /* QuickStart.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QuickStart.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FBA79EA01E9A038700179A54 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -119,7 +119,6 @@
 				FBA79E9A1E9A038700179A54 /* Frameworks */,
 				FBA79E9B1E9A038700179A54 /* Resources */,
 				62FF8D48DDB503F027F22D2C /* [CP] Embed Pods Frameworks */,
-				9A29E92CB9566AB0F008EEA5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -197,7 +196,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-QuickStart/Pods-QuickStart-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-QuickStart/Pods-QuickStart-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/ADAL/ADAL.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -206,22 +205,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-QuickStart/Pods-QuickStart-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9A29E92CB9566AB0F008EEA5 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-QuickStart/Pods-QuickStart-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-QuickStart/Pods-QuickStart-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CA99DF8CB4EFF07F56D45BE6 /* [CP] Check Pods Manifest.lock */ = {

--- a/QuickStart/ViewController.swift
+++ b/QuickStart/ViewController.swift
@@ -45,7 +45,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
     let kRedirectUri = URL(string: "adal-sample-app://com.microsoft.identity.client.sample.quickstart")
     let defaultSession = URLSession(configuration: .default)
     
-    var applicationContext : ADAuthenticationContext?
+    var applicationContext : ADALAuthenticationContext?
     var dataTask: URLSessionDataTask?
     
     @IBOutlet weak var loggingText: UITextView!
@@ -66,7 +66,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
          not interested in the specific error pass in nil.
          */
         
-        self.applicationContext = ADAuthenticationContext(authority: kAuthority, error: nil)
+        self.applicationContext = ADALAuthenticationContext(authority: kAuthority, error: nil)
         self.applicationContext?.credentialsType = AD_CREDENTIALS_AUTO
         super.viewDidLoad()
         
@@ -117,7 +117,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
                 
                 if let error = result.error {
                     if error.domain == ADAuthenticationErrorDomain,
-                        error.code == ADErrorCode.ERROR_UNEXPECTED.rawValue {
+                        error.code == ADALErrorCode.AD_ERROR_UNEXPECTED.rawValue {
                         self.updateLogging(text: "Unexpected internal error occured: \(error.description))");
                     } else {
                         self.updateLogging(text: error.description)
@@ -162,7 +162,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
                 // among other possible reasons.
                 if let error = result.error {
                     if error.domain == ADAuthenticationErrorDomain,
-                        error.code == ADErrorCode.ERROR_SERVER_USER_INPUT_NEEDED.rawValue {
+                        error.code == ADALErrorCode.AD_ERROR_SERVER_USER_INPUT_NEEDED.rawValue {
                         
                         DispatchQueue.main.async {
                             self.acquireToken() { (success) -> Void in
@@ -188,7 +188,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
         }
     }
     
-    func currentAccount() -> ADTokenCacheItem? {
+    func currentAccount() -> ADALTokenCacheItem? {
         
         
         // We retrieve our current account by getting the last account from cache. This isn't best practice. You should rely
@@ -196,7 +196,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
         // In multi-account applications, account should be retrieved by home account identifier or username instead
         
         
-        guard let cachedTokens = ADKeychainTokenCache.defaultKeychain().allItems(nil) else {
+        guard let cachedTokens = ADALKeychainTokenCache.defaultKeychain().allItems(nil) else {
             self.updateLogging(text: "Didn't find a default cache. This is very unusual.")
             
             return nil
@@ -330,7 +330,7 @@ class ViewController: UIViewController, UITextFieldDelegate, URLSessionDelegate 
             return
         }
         
-        ADKeychainTokenCache.defaultKeychain().removeAll(forUserId: account, clientId: kClientID, error: nil)
+        ADALKeychainTokenCache.defaultKeychain().removeAll(forUserId: account, clientId: kClientID, error: nil)
         self.signoutButton.isEnabled = false
         self.updateLogging(text: "Removed account for: \(account)" )
     }


### PR DESCRIPTION
Due to the conflict of "AD" prefix with Apple frameworks, we agreed to do a mass rename of the prefix to avoid additional issues and ship a new major version. This PR makes sure that our sample works after the prefix rename. 